### PR TITLE
Fix `logback-async-perf.xml` config so events may be written

### DIFF
--- a/src/main/resources/logback-async-perf.xml
+++ b/src/main/resources/logback-async-perf.xml
@@ -1,9 +1,4 @@
 <configuration debug="false">
-	
-	<appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-	  <discardingThreshold>0</discardingThreshold>
-	  <appender-ref ref="FILE" />
-	</appender>
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>target/test-output/logback-async-perf.log</file>
@@ -12,6 +7,11 @@
         <encoder>
             <pattern>%d %p [%t] %logger - %m%n</pattern>  
         </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <discardingThreshold>0</discardingThreshold>
+        <appender-ref ref="FILE" />
     </appender>
 
     <root level="DEBUG">


### PR DESCRIPTION
This resolves the ERROR starting the benchmark, so the ASYNC appender can successfully start.
```
10:55:36,573 |-ERROR in ch.qos.logback.core.joran.action.AppenderRefAction -
Could not find an appender named [FILE]. Did you define it below instead of
above in the configuration file?
```