### PR TITLE
Add Async benchmark for logback-logstash-encoder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<!-- <lb.version>1.3.0-alpha10-SNAPSHOT</lb.version> -->
 		<!-- <lb.version>1.3.0-alpha9</lb.version>  --> 
 		<lb.version>1.3.0-alpha10</lb.version>
-
+        <logback-logstash-encoder.version>7.0</logback-logstash-encoder.version>
 
 	</properties>
 
@@ -47,7 +47,12 @@
 			<type>test-jar</type>
 			<version>${lb.version}</version>
 		</dependency>
-
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logback-logstash-encoder.version}</version>
+        </dependency>
+        
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>

--- a/src/main/java/ch/qos/logback/perf/AsyncWithFileAppenderBenchmark.java
+++ b/src/main/java/ch/qos/logback/perf/AsyncWithFileAppenderBenchmark.java
@@ -47,13 +47,16 @@ public class AsyncWithFileAppenderBenchmark {
     public static final String MESSAGE = "This is a debug message";
     
     public static final String LOGBACK_ASYNC_FILE_PATH = "target/test-output/logback-async-perf.log";
+    public static final String LOGBACK_LLE_ASYNC_FILE_PATH = "target/test-output/logback-lle-async-perf.log";
+
     public static final String LOG4J2_ASYNC_FILE_PATH = "target/test-output/log4j2-async-perf.log";
     public static final String LOG4J_ASYNC_FILE_PATH = "target/test-output/log4j-async-perf.log";
                                                         
     Logger log4j2Logger;
     Logger log4j2RandomLogger;
-    org.slf4j.Logger slf4jLogger;
-    org.apache.log4j.Logger log4j1Logger;
+    org.slf4j.Logger slf4jLogger;          // logback
+    org.apache.log4j.Logger log4j1Logger;  // log4j1
+    org.slf4j.Logger lleLogger;            // logback-logstash-encoder
     
     @Setup
     public void setUp() throws Exception {
@@ -69,6 +72,7 @@ public class AsyncWithFileAppenderBenchmark {
         log4j2Logger = LogManager.getLogger(this.getClass());
         slf4jLogger = LoggerFactory.getLogger(this.getClass());
         log4j1Logger = org.apache.log4j.Logger.getLogger(this.getClass());
+        lleLogger = LoggerFactory.getLogger("LLE");
     }
 
     @TearDown
@@ -85,6 +89,7 @@ public class AsyncWithFileAppenderBenchmark {
     private void deleteLogFiles() {
     	System.out.println("Deleting files if existent.");
     	chattyDelete(LOGBACK_ASYNC_FILE_PATH);
+    	chattyDelete(LOGBACK_LLE_ASYNC_FILE_PATH);
        	chattyDelete(LOG4J2_ASYNC_FILE_PATH);
        	chattyDelete(LOG4J_ASYNC_FILE_PATH);
     }
@@ -107,6 +112,13 @@ public class AsyncWithFileAppenderBenchmark {
         slf4jLogger.debug(MESSAGE);
     }
 
+	@BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Benchmark
+    public void logbackLleFile() {
+        lleLogger.debug(MESSAGE);
+    }
+	
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Benchmark

--- a/src/main/resources/logback-async-perf.xml
+++ b/src/main/resources/logback-async-perf.xml
@@ -15,7 +15,34 @@
         </encoder>
     </appender>
 
+
+    <!-- 
+        logback-logstash-encoder based Async appender.
+     -->
+    <appender name="LLE" class="net.logstash.logback.appender.LoggingEventAsyncDisruptorAppender">
+        <!-- wait until space is available in the queue instead of dropping the event -->
+        <appendTimeout>-1</appendTimeout>
+
+        <appender name="LLE-FILE" class="ch.qos.logback.core.FileAppender">
+            <file>target/test-output/logback-lle-async-perf.log</file>
+            <bufferSize>256KB</bufferSize>
+            <immediateFlush>false</immediateFlush>  
+            <append>false</append>
+            <encoder>
+                <pattern>%d %p [%t] %logger - %m%n</pattern>
+            </encoder>
+        </appender>
+    </appender>
+    
+    
     <root level="DEBUG">
         <appender-ref ref="ASYNC" />
     </root>
+    
+    
+    <!-- LLE benchmark logs against this logger -->
+    <logger name="LLE" level="DEBUG" additivity="false">
+        <appender-ref ref="LLE" />
+    </logger>
+    
 </configuration>


### PR DESCRIPTION
The [logback-logstash-encoder](https://github.com/logfellow/logstash-logback-encoder) (LLE) project comes with an AsyncDisruptorAppender wrapper that can be used to log asynchronously to an otherwise synchronous appender.

This PR adds a benchmark in the AsyncWithFileAppenderBenchmark test suite to evaluate the LLE async solution alongside the other ones. 

A few points about the integration:
- Instead of creating a separate logback configuration file, I reused the existing one and added a new appender named "LLE"
- The "LLE" logger category logs to this new appender and has additivity turned off to avoid logging into the other appender as well
- The `logbackLleFile` benchmark logs directly to the `LLE` category to target the LLE appender.

Thanks for considering adding this benchmark to your suite.